### PR TITLE
Fix progress badges on safari

### DIFF
--- a/server/serve.go
+++ b/server/serve.go
@@ -36,7 +36,6 @@ aria-label="{{.title}}">
 <g clip-path="url(#r)">
 	<rect width="{{ .successWidth }}" height="20" fill="#4c1" />
 	<rect x="{{ .successWidth }}" width="{{ .failWidth }}" height="20" fill="#9f9f9f" />
-	<rect width="{{.width}}" height="20" fill="url(#s)" />
 </g>
 </svg>`
 


### PR DESCRIPTION
Fixes https://github.com/seriousben/badges/issues/11

The progress svg had a leftover tag from the other badge type.